### PR TITLE
FIX(export) Correct processing of request for overwriteDemand

### DIFF
--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -50,7 +50,7 @@ class ExportController extends AbstractController
         $this->view->assign('arguments', $this->request->getArguments());
 
         if (Misc::isTypo3V11()) {
-            $this->view->assign('overwriteDemand', $this->request->getArguments()['overwriteDemand'] ?? []);
+            $this->view->assign('overwriteDemand', $this->request->getParsedBody()['tx_recordsmanager_txrecordsmanagerm1_recordsmanagerexport']['overwriteDemand'] ?? []);
         }
 
         if (Misc::isTypo3V12()) {
@@ -83,15 +83,15 @@ class ExportController extends AbstractController
 
     public function getAllArguments()
     {
+        if (Misc::isTypo3V11()) {
+            return $this->request->getParsedBody();
+        }
         return $this->request->getArguments();
     }
 
     public function getOverwriteDemand($key)
     {
         $arguments = $this->getAllArguments();
-        if (Misc::isTypo3V11()) {
-            return $arguments['overwriteDemand'][$key] ?? null;
-        }
         return $arguments['tx_recordsmanager_txrecordsmanagerm1_recordsmanagerexport']['overwriteDemand'][$key] ?? null;
     }
 


### PR DESCRIPTION
Related: #17 

As my colleague Anton already mentioned in #17, we recently noticed that the export filter (start/enddate) did not work anymore in TYPO3 11 (latest v11.5.38). Now we fixed this issue in our own fork. Please test & consider merging this PR.

Some additional notes on this fix:

- my guess is that you might have successfully tested this functionality in earlier versions of TYPO3 v11 -> maybe this solution does not work for these (outdated) versions
- to be honest, we did not test this in TYPO3 v12 and used the `Misc::isTypo3V11` helper instead to make sure that our fix is only applied to v11. Probably, the same code would also work in v12, so it could be shortened, maybe even the bug is still present in v12